### PR TITLE
beam/feat/edit-profile-picture

### DIFF
--- a/src/components/account/EditProfilePictureDialog.tsx
+++ b/src/components/account/EditProfilePictureDialog.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { GlobalButton, GlobalInput } from "../globalComponents";
+import { AppToast } from "@/lib/app-toast";
+
+interface EditProfilePictureDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (url: string) => void;
+  currentImageUrl?: string;
+}
+
+export function EditProfilePictureDialog({
+  open,
+  onOpenChange,
+  onSave,
+  currentImageUrl = "",
+}: EditProfilePictureDialogProps) {
+  const [imageUrl, setImageUrl] = useState(currentImageUrl);
+
+  useEffect(() => {
+    setImageUrl(currentImageUrl);
+  }, [currentImageUrl]);
+
+  const handleSave = () => {
+    if (imageUrl.trim()) {
+      onSave(imageUrl);
+      onOpenChange(false);
+    }
+    AppToast.success("Profile picture updated successfully!");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent 
+        showCloseButton={false} 
+        className="
+          font-chakra text-neutral-white w-[90vw] max-w-md 
+          p-0 border-none rounded-[2rem] bg-transparent shadow-lg gap-0
+        "
+      >
+        {/* Header Section */}
+        <DialogHeader className="bg-primary rounded-t-[2rem] p-4">
+          <DialogTitle className="text-center text-xl tracking-wider">
+            EDIT PROFILE PICTURE
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Content & Footer Section */}
+        <div className="bg-primary-500 rounded-b-[2rem] p-6">
+          {/* Input Section */}
+          <div className="flex flex-col gap-2">
+            <label htmlFor="pictureUrl" className="text-sm text-neutral-white">
+              New Picture URL
+            </label>
+            <GlobalInput
+              id="pictureUrl"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+              placeholder="Enter picture URL"
+            />
+          </div>
+
+          {/* Footer Section */}
+          <DialogFooter className="mt-6 flex w-full items-center justify-center gap-4">
+            <div className="w-full flex justify-center items-center gap-4">
+                <GlobalButton
+                    onClick={() => onOpenChange(false)}
+                    variant="primary"
+                    >
+                    Cancel
+                    </GlobalButton>
+                    <GlobalButton
+                    onClick={handleSave}
+                    variant="secondary" 
+                    >
+                    Save
+                </GlobalButton>
+            </div>
+
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/testeditprofile.tsx
+++ b/src/pages/testeditprofile.tsx
@@ -1,0 +1,32 @@
+import { DefaultLayout, GlobalButton } from "@/components/globalComponents";
+import { EditProfilePictureDialog } from "@/components/account/EditProfilePictureDialog";
+import { useState } from "react";
+
+
+export default function TestEditProfilePage() {
+
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+    const handleSavePicture = (newUrl: string) => {
+        console.log("New image URL to save:", newUrl);
+        // TODO: ใส่ logic การเรียก API เพื่ออัปเดต URL รูปภาพที่นี่
+    };
+    return (
+        <DefaultLayout>
+            <GlobalButton
+                variant="primary"
+                size="lg"
+                onClick={() => setIsDialogOpen(true)}
+            >
+                Edit Profile
+            </GlobalButton>   
+
+            <EditProfilePictureDialog
+                open={isDialogOpen}
+                onOpenChange={setIsDialogOpen}
+                onSave={handleSavePicture}
+                currentImageUrl="https://example.com/current-image.jpg"
+            />
+        </DefaultLayout>
+    );
+}


### PR DESCRIPTION
This pull request introduces a new dialog component for editing a user's profile picture and adds a test page to demonstrate its usage. The main focus is on improving the user experience for updating profile pictures by providing a dedicated modal interface and integrating it into the application for testing.

**New Feature: Edit Profile Picture Dialog**
* Added `EditProfilePictureDialog` component that provides a modal for users to input and save a new profile picture URL. It includes form handling, UI styling, and success toast notification. (`src/components/account/EditProfilePictureDialog.tsx`)

**Integration & Testing**
* Created `testeditprofile.tsx` page to showcase and test the new dialog. This page demonstrates opening the dialog, handling save events, and passing the current image URL. (`src/pages/testeditprofile.tsx`)

<img width="980" height="542" alt="image" src="https://github.com/user-attachments/assets/39bc0736-02e8-4f66-ba51-327e4f691d11" />
